### PR TITLE
Feature/trophic level

### DIFF
--- a/networkx/algorithms/centrality/tests/test_trophic.py
+++ b/networkx/algorithms/centrality/tests/test_trophic.py
@@ -138,8 +138,17 @@ class TestTrophicMeasures:
 
     # Check it raises the correct error with graphs with only non-basal nodes
     @raises(np.linalg.LinAlgError)
-    def test_singular_matrix(self):
+    def test_torphic_levels_singular_matrix(self):
 
         matrix = np.identity(4)
         G = nx.from_numpy_matrix(matrix, create_using=nx.DiGraph)
         result = nx.trophic_levels(G)        
+
+
+    def test_trophic_differences(self):
+
+        matrix_a = np.array([[0,0],[1,0]])
+        G = nx.from_numpy_matrix(matrix_a, create_using=nx.DiGraph)
+        diffs = nx.trophic_differences(G)
+        assert almost_equal(diffs[(1,0)], 1)
+

--- a/networkx/algorithms/centrality/tests/test_trophic.py
+++ b/networkx/algorithms/centrality/tests/test_trophic.py
@@ -147,8 +147,22 @@ class TestTrophicMeasures:
 
     def test_trophic_differences(self):
 
-        matrix_a = np.array([[0,0],[1,0]])
+        matrix_a = np.array([[0,1],[0,0]])
         G = nx.from_numpy_matrix(matrix_a, create_using=nx.DiGraph)
         diffs = nx.trophic_differences(G)
-        assert almost_equal(diffs[(1,0)], 1)
+        assert almost_equal(diffs[(0,1)], 1)
 
+
+        matrix_b = np.array([[0,1,1,0],
+            [0,0,1,1],
+            [0,0,0,1],
+            [0,0,0,0]])
+        G = nx.from_numpy_matrix(matrix_b, create_using=nx.DiGraph)
+        diffs = nx.trophic_differences(G)
+        print(diffs)
+        assert almost_equal(diffs[(0,1)], 1)
+        assert almost_equal(diffs[(0,2)], 1.5)
+        assert almost_equal(diffs[(1,2)], 0.5)
+        assert almost_equal(diffs[(1,3)], 1.25)
+        assert almost_equal(diffs[(2,3)], 0.75)
+        

--- a/networkx/algorithms/centrality/tests/test_trophic.py
+++ b/networkx/algorithms/centrality/tests/test_trophic.py
@@ -108,4 +108,29 @@ class TestTrophicMeasures:
         for ind in range(4):
             assert almost_equal(d[ind], expected_result[ind])
 
+    def test_trophic_levels_even_more_complex(self):
+
+
+        # Another, bigger matrix
+        matrix = np.array([
+        [0, 0, 0, 0, 0],
+        [0, 1, 0, 1, 0],
+        [1, 0, 0, 0, 0],
+        [0, 1, 0, 0, 0],
+        [0, 0, 0, 1, 0]])
+
+        # Generated this linear system using pen and paper:
+        K = np.matrix([
+        [1, 0,  -1,0,   0],
+        [0, .5, 0,  -.5,    0],
+        [0, 0,  1,  0,      0],
+        [0, -.5,0,  1,      -.5],
+        [0, 0,  0,  0,      1],
+        ])
+        result_1 = np.ravel(np.matmul(np.linalg.inv(K), np.ones(5)))
+        G = nx.from_numpy_matrix(matrix, create_using=nx.DiGraph)
+        result_2 = nx.trophic_levels(G)
+
+        for ind in range(5):
+            assert almost_equal(result_1[ind], result_2[ind])        
 

--- a/networkx/algorithms/centrality/tests/test_trophic.py
+++ b/networkx/algorithms/centrality/tests/test_trophic.py
@@ -165,4 +165,58 @@ class TestTrophicMeasures:
         assert almost_equal(diffs[(1,2)], 0.5)
         assert almost_equal(diffs[(1,3)], 1.25)
         assert almost_equal(diffs[(2,3)], 0.75)
+
+    def test_trophic_coherence_no_cannibalism(self):
+
+        matrix_a = np.array([[0,1],[0,0]])
+        G = nx.from_numpy_matrix(matrix_a, create_using=nx.DiGraph)
+        q = nx.trophic_coherence(G, cannibalism=False)
+        assert almost_equal(q,0)
+
+    
+        matrix_b = np.array([[0,1,1,0],
+            [0,0,1,1],
+            [0,0,0,1],
+            [0,0,0,0]])
+        G = nx.from_numpy_matrix(matrix_b, create_using=nx.DiGraph)
+        q = nx.trophic_coherence(G, cannibalism=False)
+        assert almost_equal(q, np.std([1,1.5,0.5,0.75,1.25]))
+
+
+        matrix_c = np.array([[0,1,1,0],
+            [0,1,1,1],
+            [0,0,0,1],
+            [0,0,0,1]])
+        G = nx.from_numpy_matrix(matrix_c, create_using=nx.DiGraph)
+        q = nx.trophic_coherence(G, cannibalism=False)
+        # Ignore the self-link
+        assert almost_equal(q, np.std([1,1.5,0.5,0.75,1.25]))
+        
+
+    def test_trophic_coherence_cannibalism(self):
+
+        matrix_a = np.array([[0,1],[0,0]])
+        G = nx.from_numpy_matrix(matrix_a, create_using=nx.DiGraph)
+        q = nx.trophic_coherence(G, cannibalism=True)
+        assert almost_equal(q,0)        
+
+
+        matrix_b = np.matrix([
+        [0, 0, 0, 0, 0],
+        [0, 1, 0, 1, 0],
+        [1, 0, 0, 0, 0],
+        [0, 1, 0, 0, 0],
+        [0, 0, 0, 1, 0]])
+        G = nx.from_numpy_matrix(matrix_b, create_using=nx.DiGraph)
+        q = nx.trophic_coherence(G, cannibalism=True)
+        assert almost_equal(q,2)        
+
+        matrix_c = np.array([[0,1,1,0],
+            [0,0,1,1],
+            [0,0,0,1],
+            [0,0,0,0]])
+        G = nx.from_numpy_matrix(matrix_c, create_using=nx.DiGraph)
+        q = nx.trophic_coherence(G, cannibalism=True)
+        # Ignore the self-link
+        assert almost_equal(q, np.std([1,1.5,0.5,0.75,1.25]))
         

--- a/networkx/algorithms/centrality/tests/test_trophic.py
+++ b/networkx/algorithms/centrality/tests/test_trophic.py
@@ -3,6 +3,8 @@
 import networkx as nx
 import numpy as np
 from networkx.testing import almost_equal
+from nose.tools import raises
+
 
 class TestTrophicMeasures:
     def test_trophic_levels(self):
@@ -134,3 +136,10 @@ class TestTrophicMeasures:
         for ind in range(5):
             assert almost_equal(result_1[ind], result_2[ind])        
 
+    # Check it raises the correct error with graphs with only non-basal nodes
+    @raises(np.linalg.LinAlgError)
+    def test_singular_matrix(self):
+
+        matrix = np.identity(4)
+        G = nx.from_numpy_matrix(matrix, create_using=nx.DiGraph)
+        result = nx.trophic_levels(G)        

--- a/networkx/algorithms/centrality/trophic.py
+++ b/networkx/algorithms/centrality/trophic.py
@@ -4,7 +4,7 @@ import networkx as nx
 
 from networkx.utils import not_implemented_for
 
-__all__ = ['trophic_levels', 'trophic_differences']
+__all__ = ['trophic_levels', 'trophic_differences', 'trophic_coherence']
 
 
 @not_implemented_for('undirected')
@@ -78,7 +78,28 @@ def trophic_levels(G, weight='weight'):
 
 @not_implemented_for('undirected')
 def trophic_differences(G, weight='weight'):
-    """Trophic difference for each edge is $x_ij = s_j - s_i$
+    r"""Compute the trophic difference of a graph.
+
+    Trophic difference for each edge is 
+
+    .. math::
+        x_ij = s_j - s_i
+    Johnson et al [1]_.
+
+    Parameters
+    ----------
+    G : DiGraph
+        A directed networkx graph
+
+    Returns
+    -------
+    diffs : dict
+        Dictionary of edges with trophic differences as the value.
+
+    References
+    ----------
+    .. [1] Samuel Johnson, Virginia Dominguez-Garcia, Luca Donetti, Miguel A. Munoz (2014) PNAS
+        "Trophic coherence determines food-web stability"
     """
     levels = trophic_levels(G, weight=weight)
     diffs = {}
@@ -88,9 +109,37 @@ def trophic_differences(G, weight='weight'):
 
 
 @not_implemented_for('undirected')
-def trophic_coherence(G, weight='weight'):
-    """Trophic coherence is the standard deviation of trophic differences between all edges
-    in a graph
+def trophic_coherence(G, weight='weight', cannibalism=False):
+    r"""Compute the trophic coherence of a graph.
+
+    Trophic coherence is defined by [1] as the standard deviation of the trophic 
+    differences of the edges of a directed graph
+    
+    Parameters
+    ----------
+    G : DiGraph
+        A directed networkx graph
+    
+    cannibalism: Boolean
+        If set to False, self edges are not considered in the calculation
+
+    Returns
+    -------
+    trophic_coherence : float
+        The trophic coherence of a graph
+
+    References
+    ----------
+    .. [1] Samuel Johnson, Virginia Dominguez-Garcia, Luca Donetti, Miguel A. Munoz (2014) PNAS
+        "Trophic coherence determines food-web stability"
     """
-    diffs = trophic_differences(G, weight=weight)
+
+    if cannibalism:
+        diffs = trophic_differences(G, weight=weight)
+    else:
+        # If no cannibalism, remove self-edges
+        # Make a copy so we do not change G's edges in memory
+        G_2 = G.copy()
+        G_2.remove_edges_from(nx.selfloop_edges(G_2))
+        diffs = trophic_differences(G_2, weight=weight)
     return np.std(list(diffs.values()))

--- a/networkx/algorithms/centrality/trophic.py
+++ b/networkx/algorithms/centrality/trophic.py
@@ -4,7 +4,7 @@ import networkx as nx
 
 from networkx.utils import not_implemented_for
 
-__all__ = ['trophic_levels']
+__all__ = ['trophic_levels', 'trophic_differences']
 
 
 @not_implemented_for('undirected')
@@ -76,16 +76,18 @@ def trophic_levels(G, weight='weight'):
     return levels
 
 
+@not_implemented_for('undirected')
 def trophic_differences(G, weight='weight'):
-    """Trophic difference for each edge is $x_ij = s_i - s_j$
+    """Trophic difference for each edge is $x_ij = s_j - s_i$
     """
     levels = trophic_levels(G, weight=weight)
     diffs = {}
     for u, v in G.edges:
-        diffs[(u, v)] = levels[u] - levels[v]
+        diffs[(u, v)] = levels[v] - levels[u]
     return diffs
 
 
+@not_implemented_for('undirected')
 def trophic_coherence(G, weight='weight'):
     """Trophic coherence is the standard deviation of trophic differences between all edges
     in a graph

--- a/networkx/algorithms/centrality/trophic.py
+++ b/networkx/algorithms/centrality/trophic.py
@@ -53,7 +53,12 @@ def trophic_levels(G, weight='weight'):
     # calculate trophic levels
     nn = p.shape[0]
     i = np.eye(nn)
-    n = np.linalg.inv(i - p)
+    try:
+        n = np.linalg.inv(i - p)
+    except np.linalg.LinAlgError as err:
+        # LinAlgError is raised when there is a non-basal node
+        err.args = (err.args[0] + ". Trophic levels are only defined for graphs with at least one basal node i.e. one node with no incoming edges.",) + err.args[1:]
+        raise
     y = n.sum(axis=1) + 1
 
     levels = {}


### PR DESCRIPTION
Hey Tom

Sorry its been a while. I've added some changes, see what you think. As far as I'm concerned, I think everything is working as it should be. To summarise:

- I added some error handling behaviour if there is a graph without a non-basal node. Its still the LinAlg error from numpy, but the error message now also explains that trophic levels are not defined for graphs without basal nodes.  
- The trophic difference calculation was giving negative trophic differences, I think that they should be positive so I switched that round. 
- In Johnson's paper he uses trophic coherence with and without cannibalism, so I added that as a Boolean variable in the function. If cannibalism is set to False then the calculation is done without considering self-links. I know that has been the standard for at least some of the papers so far. 
- I added some more tests for everything
- I also updated the function definitions, please feel free to change those if you're not happy with it, I just used your initial definition as a template

Let me know what you think. As always, I'm happy to discuss anything and open to changes.

Best,
Charlie